### PR TITLE
Fix compilation error in tutorials for linux

### DIFF
--- a/tutorials/60_mesh_export/premake4.lua
+++ b/tutorials/60_mesh_export/premake4.lua
@@ -12,9 +12,13 @@ project "60_mesh_export"
     
     buildoptions "-std=c++11"
 
-	configuration {"x64"}
-	links {"RadeonProRender64", "RprLoadStore64", "ProRenderGLTF"}
-	
+    configuration {"x64"}
+    links {"RadeonProRender64", "RprLoadStore64", "ProRenderGLTF"}
+
+    if os.istarget("linux") then
+        linkoptions "-fopenmp"
+    end
+
     configuration {"x64", "Debug"}
         targetdir "../Bin"
     configuration {"x64", "Release"}

--- a/tutorials/61_mesh_import/premake4.lua
+++ b/tutorials/61_mesh_import/premake4.lua
@@ -12,9 +12,13 @@ project "61_mesh_import"
     
     buildoptions "-std=c++11"
 
-	configuration {"x64"}
-	links {"RadeonProRender64", "RprLoadStore64", "ProRenderGLTF"}
-	
+    configuration {"x64"}
+    links {"RadeonProRender64", "RprLoadStore64", "ProRenderGLTF"}
+
+    if os.istarget("linux") then
+        linkoptions "-fopenmp"
+    end
+
     configuration {"x64", "Debug"}
         targetdir "../Bin"
     configuration {"x64", "Release"}


### PR DESCRIPTION
GLTF library contains implicit dependency from openmp. Latest gcc version doesn't include openmp by default, so it is requried to bypass -fopenmp flag for linker

This commit fix compilation of:

* 60_mesh_export
* 61_mesh_import
```
RadeonProRender/binUbuntu18/libProRenderGLTF.so: undefined reference to `omp_get_thread_num'
RadeonProRender/binUbuntu18/libProRenderGLTF.so: undefined reference to `omp_get_num_threads'
RadeonProRender/binUbuntu18/libProRenderGLTF.so: undefined reference to `omp_get_thread_num'
RadeonProRender/binUbuntu18/libProRenderGLTF.so: undefined reference to `omp_get_num_threads'
RadeonProRender/binUbuntu18/libProRenderGLTF.so: undefined reference to `GOMP_parallel'
RadeonProRender/binUbuntu18/libProRenderGLTF.so: undefined reference to `GOMP_parallel'
```

:Testing Performed:
Compiled and run at gentoo linux